### PR TITLE
Allow to jump from category to spec

### DIFF
--- a/spectacular/Categories/IDEEditorContext+TBSpectacular.m
+++ b/spectacular/Categories/IDEEditorContext+TBSpectacular.m
@@ -14,8 +14,14 @@
 
 - (void)tb_jumpToTestOrCounterpart
 {
-    NSString *counterpartFileName = [[self currentHistoryItem] tb_counterpartName];
+    NSString *counterpartFileName = [[self currentHistoryItem] tb_counterpartName:NO];
     DVTFilePath *counterpartFilePath = [[[self workspace] index] tb_filePathForFileWithName:counterpartFileName];
+
+    // what if curent item is a category  for class? We can try to find Spec for its class.
+    if (!counterpartFilePath && ![[self currentHistoryItem] tb_isSpecFile]) {
+        counterpartFileName = [[self currentHistoryItem] tb_counterpartName:YES];
+        counterpartFilePath = [[[self workspace] index] tb_filePathForFileWithName:counterpartFileName];
+    }
 
     if (counterpartFilePath)
     {

--- a/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.h
+++ b/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.h
@@ -10,7 +10,18 @@
 
 @interface IDEEditorHistoryItem (TBSpectacular)
 
-- (NSString *)tb_counterpartName;
+/**
+ If YES is passed:
+    Foo => FooSpec
+    Foo+Bar => FooSpec
+    FooSpec => Foo
+
+ If NO is passed:
+    Foo => FooSpec
+    Foo+Bar => Foo+BarSpec
+    FooSpec => Foo
+ */
+- (NSString *)tb_counterpartName:(BOOL)ignoreCategory;
 - (BOOL)tb_isSpecFile;
 
 @end

--- a/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.m
+++ b/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.m
@@ -12,14 +12,18 @@
 
 #pragma mark - Public Methods
 
-- (NSString *)tb_counterpartName
+- (NSString *)tb_counterpartName:(BOOL)ignoreCategory
 {
     NSString *activeFileName = [self _tb_baseFileName];
 
     if ([self tb_isSpecFile])
         return [activeFileName stringByReplacingOccurrencesOfString:@"Spec" withString:@".m"];
-    else
-        return [NSString stringWithFormat:@"%@Spec.m", activeFileName];
+    else {
+      if (ignoreCategory)
+          activeFileName = [activeFileName componentsSeparatedByString:@"+"][0];
+
+      return [activeFileName stringByAppendingString:@"Spec.m"];
+    }
 }
 
 - (BOOL)tb_isSpecFile


### PR DESCRIPTION
In project I work on we don't modify NSManagedObject's subclasses generated by xcode. All our changes go to `Foo+Bar.{h,m}`. But kiwi spec is located in `FooSpec.m`. With this change this plugin tries to find `Foo+BarSpec.m` first and if no result, then `FooSpec.m` gets a chance.

It doesn't cover back jump: `FooSpec.m` => `Foo+BarSpec.m`. Probably it can be next improvement. for example we can remember the last jump and use it to determine where the next jump should be.
