### PR TITLE
Jump to header from spec file

### DIFF
--- a/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.m
+++ b/spectacular/Categories/IDEEditorHistoryItem+TBSpectacular.m
@@ -17,7 +17,7 @@
     NSString *activeFileName = [self _tb_baseFileName];
 
     if ([self tb_isSpecFile])
-        return [activeFileName stringByReplacingOccurrencesOfString:@"Spec" withString:@".m"];
+        return [activeFileName stringByReplacingOccurrencesOfString:@"Spec" withString:@".h"];
     else
         return [NSString stringWithFormat:@"%@Spec.m", activeFileName];
 }


### PR DESCRIPTION
I made pretty extensive use of this shortcut today. I noticed after a while that after jumping from the spec file, it would usually be followed up a jump to the header file. I think that jumping to the header would keep me focused on the interface under test without getting distracted by implementation details.
